### PR TITLE
Helpcenter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A fun utility bot built by and for the Codecademy Community to seperate fun/util
 
 ## Current Commands
 
-| Command       | Arguments  | Permission | Description                                    |
-| :------------ | :--------- | :--------- | :--------------------------------------------- |
-| `/ping`       | N/A        | Everyone   | Displays bot latency.                          |
-| `/format`     | {language} | Everyone   | Formats a codeblock.                           |
-| `/helpcenter` | {plaintext}| Everyone   | Displays information for accessing helpcenter. |
+| Command       | Arguments   | Permission | Description                                    |
+| :------------ | :---------- | :--------- | :--------------------------------------------- |
+| `/ping`       | N/A         | Everyone   | Displays bot latency.                          |
+| `/format`     | {language}  | Everyone   | Formats a codeblock.                           |
+| `/helpcenter` | {plaintext} | Everyone   | Displays information for accessing helpcenter. |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A fun utility bot built by and for the Codecademy Community to seperate fun/util
 
 ## Current Commands
 
-| Command       | Arguments   | Permission | Description                                    |
-| :------------ | :---------- | :--------- | :--------------------------------------------- |
-| `/ping`       | N/A         | Everyone   | Displays bot latency.                          |
-| `/format`     | {language}  | Everyone   | Formats a codeblock.                           |
-| `/helpcenter` | {plaintext} | Everyone   | Displays information for accessing helpcenter. |
+| Command       | Arguments   | Permission | Description                                                                |
+| :------------ | :---------- | :--------- | :------------------------------------------------------------------------- |
+| `/ping`       | N/A         | Everyone   | Displays bot latency.                                                      |
+| `/format`     | {language}  | Everyone   | Formats a codeblock.                                                       |
+| `/helpcenter` | {plaintext} | Everyone   | Provides links to Codecademy's Help Center (either embedded or plaintext). |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A fun utility bot built by and for the Codecademy Community to seperate fun/util
 
 ## Current Commands
 
-| Command   | Arguments  | Permission | Description           |
-| :-------- | :--------- | :--------- | :-------------------- |
-| `/ping`   | N/A        | Everyone   | Displays bot latency. |
-| `/format` | {language} | Everyone   | Formats a codeblock.  |
+| Command       | Arguments  | Permission | Description                                    |
+| :------------ | :--------- | :--------- | :--------------------------------------------- |
+| `/ping`       | N/A        | Everyone   | Displays bot latency.                          |
+| `/format`     | {language} | Everyone   | Formats a codeblock.                           |
+| `/helpcenter` | {plaintext}| Everyone   | Displays information for accessing helpcenter. |

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -4,7 +4,7 @@ const { MessageEmbed } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('helpcenter')
-    .setDescription('Provies information to access the helcenter!')
+    .setDescription('Provides information to access the helpcenter!')
     .addBooleanOption((option) =>
       option
         .setName('plaintext')

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -6,43 +6,46 @@ module.exports = {
     .setName('helpcenter')
     .setDescription('Provies information to access the helcenter!')
     .addStringOption((option) =>
-        option
-            .setName("plaintext")
-            .setDescription("Provides helpcenter in plaintext format")
-            .setRequired(false)
+      option
+        .setName('plaintext')
+        .setDescription('Provides helpcenter in plaintext format')
+        .setRequired(false)
     ),
 
-    async execute(interaction) {
-        if (interaction.options.getString('plaintext') == "plaintext" || interaction.options.getString('plaintext') == "true") {
-            await interaction.reply({
-                content: (
-                '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
-                '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
-                '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
-                'All billing-related queries should be directed to the Submit A Request form linked above.'),
-                fetchReply: true,
-            })
-        } else {
-            const HelpCenterMessage = new MessageEmbed()
-                .setTitle('Codecademy Help Center Resources')
-                .setColor('DARK_NAVY')
-                .addField(
-                  'Codecademy Help Center',
-                  'https://help.codecademy.com/hc/en-us'
-                )
-                .addField(
-                  'Submit A Request',
-                  'https://help.codecademy.com/hc/en-us/requests/new'
-                )
-                .addField(
-                  'Bug Reporting',
-                  'To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.'
-                )
-                .setFooter(
-                  'All billing-related queries should be directed to the Submit A Request form linked above.'
-                );
-            
-            interaction.reply({embeds: [HelpCenterMessage]});
-        }
+  async execute(interaction) {
+    if (
+      interaction.options.getString('plaintext') == 'plaintext' ||
+      interaction.options.getString('plaintext') == 'true'
+    ) {
+      await interaction.reply({
+        content:
+          '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
+          '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
+          '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
+          'All billing-related queries should be directed to the Submit A Request form linked above.',
+        fetchReply: true,
+      });
+    } else {
+      const HelpCenterMessage = new MessageEmbed()
+        .setTitle('Codecademy Help Center Resources')
+        .setColor('DARK_NAVY')
+        .addField(
+          'Codecademy Help Center',
+          'https://help.codecademy.com/hc/en-us'
+        )
+        .addField(
+          'Submit A Request',
+          'https://help.codecademy.com/hc/en-us/requests/new'
+        )
+        .addField(
+          'Bug Reporting',
+          'To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.'
+        )
+        .setFooter(
+          'All billing-related queries should be directed to the Submit A Request form linked above.'
+        );
+
+      interaction.reply({ embeds: [HelpCenterMessage] });
     }
+  },
 };

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -1,0 +1,49 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageEmbed } = require('discord.js');
+const Discord = require('discord.js')
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('helpcenter')
+    .setDescription('Provies information to access the helcenter!')
+    .addStringOption((option) =>
+        option
+            .setName("plaintext")
+            .setDescription("Provides helpcenter in plaintext format")
+            .setRequired(false)
+    ),
+
+    async execute(interaction) {
+        if (interaction.options.getString('plaintext') == "plaintext" || interaction.options.getString('plaintext') == "true") {
+            await interaction.reply({
+                content: (
+                '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
+                '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
+                '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
+                'All billing-related queries should be directed to the Submit A Request form linked above.'),
+                fetchReply: true,
+            })
+        } else {
+            const HelpCenterMessage = new MessageEmbed()
+                .setTitle('Codecademy Help Center Resources')
+                .setColor('DARK_NAVY')
+                .addField(
+                  'Codecademy Help Center',
+                  'https://help.codecademy.com/hc/en-us'
+                )
+                .addField(
+                  'Submit A Request',
+                  'https://help.codecademy.com/hc/en-us/requests/new'
+                )
+                .addField(
+                  'Bug Reporting',
+                  'To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.'
+                )
+                .setFooter(
+                  'All billing-related queries should be directed to the Submit A Request form linked above.'
+                );
+            
+            interaction.reply({embeds: [HelpCenterMessage]});
+        }
+    }
+};

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -5,7 +5,7 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('helpcenter')
     .setDescription('Provies information to access the helcenter!')
-    .addStringOption((option) =>
+    .addBooleanOption((option) =>
         option
             .setName("plaintext")
             .setDescription("Provides helpcenter in plaintext format")
@@ -13,14 +13,13 @@ module.exports = {
     ),
 
     async execute(interaction) {
-        if (interaction.options.getString('plaintext') == "plaintext" || interaction.options.getString('plaintext') == "true") {
+        if (interaction.options.getBoolean('plaintext') == true) {
             await interaction.reply({
                 content: (
                 '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
                 '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
                 '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
                 'All billing-related queries should be directed to the Submit A Request form linked above.'),
-                fetchReply: true,
             })
         } else {
             const HelpCenterMessage = new MessageEmbed()

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -13,9 +13,7 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    if (
-      interaction.options.getBoolean('plaintext') == true
-    ) {
+    if (interaction.options.getBoolean('plaintext') == true) {
       await interaction.reply({
         content:
           '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +

--- a/src/commands/helpcenter.js
+++ b/src/commands/helpcenter.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageEmbed } = require('discord.js');
-const Discord = require('discord.js')
 
 module.exports = {
   data: new SlashCommandBuilder()


### PR DESCRIPTION
## What issue is this solving?
Closes #6 

### Description
<!-- Brief description of change -->
Adds the `cc!helpcenter` command as a slash command on this bot.
![image](https://user-images.githubusercontent.com/78568904/135719170-c2d4a425-dc16-4dd2-97c8-8632c2ab6369.png)

`/helpcenter plaintext:plaintext` or `/helpcenter plaintext:true` displays helpcenter in plaintext form.



## Any helpful knowledge/context for the reviewer?
- Is a re-seeding of the database necessary?
No

- Any new dependencies to install?
No
            
- Any special requirements to test?
 No



### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
