### PR TITLE
Add stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ A fun utility bot built by and for the Codecademy Community to seperate fun/util
 | `/ping`       | N/A         | Everyone   | Displays bot latency.                                                      |
 | `/format`     | {language}  | Everyone   | Formats a codeblock.                                                       |
 | `/helpcenter` | {plaintext} | Everyone   | Provides links to Codecademy's Help Center (either embedded or plaintext). |
+| `/stats`      | N/A         | Everyone   | Displays basic server statistics.                                          |

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -3,16 +3,18 @@ const { MessageEmbed } = require('discord.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
-  .setName('stats')
-  .setDescription('Display basic server stats.'),
-  
+    .setName('stats')
+    .setDescription('Display basic server stats.'),
+
   async execute(interaction) {
     const fetchedMembers = await interaction.guild.members.fetch();
     const totalOnline = fetchedMembers.filter(
-      (member) => (member.presence != null && member.presence.status !== 'offline')
-      ).size;
+      (member) =>
+        member.presence != null && member.presence.status !== 'offline'
+    ).size;
     const totalOffline = fetchedMembers.filter(
-      (member) => (member.presence == null || member.presence.status === 'offline')
+      (member) =>
+        member.presence == null || member.presence.status === 'offline'
     ).size;
 
     const Embed = new MessageEmbed();
@@ -20,7 +22,7 @@ module.exports = {
     Embed.addField('Online Members', `${totalOnline}`);
     Embed.addField('Offline Members', `${totalOffline}`);
     Embed.addField('Total Members', `${interaction.guild.memberCount}`);
-    
+
     interaction.reply({ embeds: [Embed] });
   },
 };

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+  .setName('stats')
+  .setDescription('Display basic server stats.'),
+  
+  async execute(interaction) {
+    const fetchedMembers = await interaction.guild.members.fetch();
+    const totalOnline = fetchedMembers.filter(
+      (member) => (member.presence != null && member.presence.status !== 'offline')
+      ).size;
+    const totalOffline = fetchedMembers.filter(
+      (member) => (member.presence == null || member.presence.status === 'offline')
+    ).size;
+
+    const Embed = new MessageEmbed();
+    Embed.setTitle('Server Stats');
+    Embed.addField('Online Members', `${totalOnline}`);
+    Embed.addField('Offline Members', `${totalOffline}`);
+    Embed.addField('Total Members', `${interaction.guild.memberCount}`);
+    
+    interaction.reply({ embeds: [Embed] });
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,12 @@ const { Client, Collection, Intents } = require('discord.js');
 require('dotenv').config();
 
 const client = new Client({
-  intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_PRESENCES],
+  intents: [
+    Intents.FLAGS.GUILDS,
+    Intents.FLAGS.GUILD_MESSAGES,
+    Intents.FLAGS.GUILD_MEMBERS,
+    Intents.FLAGS.GUILD_PRESENCES,
+  ],
 });
 const commandsDir = `${__dirname}/commands`;
 const eventsDir = `${__dirname}/events`;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { Client, Collection, Intents } = require('discord.js');
 require('dotenv').config();
 
 const client = new Client({
-  intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+  intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_PRESENCES],
 });
 const commandsDir = `${__dirname}/commands`;
 const eventsDir = `${__dirname}/events`;


### PR DESCRIPTION
## What issue is this solving?
Closes #5 

### Description
Ported over the `cc!stats` command on our mod bot here and made it a slash command. Also added `GUILD_MEMBERS` AND `GUILD_PRESENCES` as new intents.

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No
  - (e.g., admin perms, alt account, etc.)
  
### Feelings gif (optional)
![frustrated Stitch](https://media.giphy.com/media/OOezqqxPB8aJ2/giphy.gif)
Why?
![infinite errors](https://user-images.githubusercontent.com/68347113/135738331-76435bdf-66d4-4ffd-b73f-77edba71127c.png)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
