### PR TITLE
fix msg delete bug on multiple format commands

### DIFF
--- a/src/commands/format.js
+++ b/src/commands/format.js
@@ -40,13 +40,11 @@ async function formatCode(interaction) {
   const msg = messages.first();
   const code = msg.content;
   
-  try {
-    await interaction.channel.messages.delete(msg.id);
-  } catch (error) {
+  interaction.channel.messages.delete(msg.id).catch((error) => {
     if (error.code !== Constants.APIErrors.UNKNOWN_MESSAGE) {
       console.error('Failed to delete the message:', error);
     }
-  }
+  });
 
   const formatted = codeBlock(language, code);
   interaction.editReply(formatted);

--- a/src/commands/format.js
+++ b/src/commands/format.js
@@ -1,3 +1,4 @@
+const { Constants } = require('discord.js');
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { codeBlock } = require('@discordjs/builders');
 
@@ -38,7 +39,14 @@ async function formatCode(interaction) {
 
   const msg = messages.first();
   const code = msg.content;
-  interaction.channel.messages.delete(msg.id);
+  
+  try {
+    await interaction.channel.messages.delete(msg.id);
+  } catch (error) {
+    if (error.code !== Constants.APIErrors.UNKNOWN_MESSAGE) {
+      console.error('Failed to delete the message:', error);
+    }
+  }
 
   const formatted = codeBlock(language, code);
   interaction.editReply(formatted);

--- a/src/commands/format.js
+++ b/src/commands/format.js
@@ -39,7 +39,7 @@ async function formatCode(interaction) {
 
   const msg = messages.first();
   const code = msg.content;
-  
+
   interaction.channel.messages.delete(msg.id).catch((error) => {
     if (error.code !== Constants.APIErrors.UNKNOWN_MESSAGE) {
       console.error('Failed to delete the message:', error);


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #15

### Description
There is a bug in the /format command if you enter just the command more than one time before entering some code to format. The bot crashes with an Unhandled Promise Rejection with a DiscordAPIError/Unknown Message when the format command is trying to delete a nonexistent message.

## Any helpful knowledge/context for the reviewer?
In this case 2+ /format commands are both listening for 60 seconds for code input. Only one of them deletes the msg and therefore there is a bug when the other command tries to delete the same msg. Implemented fix as described here  to ignore error logging due to unknown message errors: https://discordjs.guide/popular-topics/errors.html#code 

We may also handle promise rejections globally in a separate PR as an additional barrier to API errors.

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
